### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Then start the server:
 npm run start
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hypescale-storyblok-mcp-server).
+
 ## Requirements
 
 - Node.js >= 20


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hypescale-storyblok-mcp-server).